### PR TITLE
Add ssh keys to authorize_keys when pairing

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 (The MIT License)
 
-Copyright (c) 2009-2011 Rogelio J. Samour
+Copyright (c) 2009-2015 Rogelio J. Samour
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Features:
 
 * Persists pair(s) between different terminal instances.
 * Creates a unique email address for the pair. (e.g. dev+fry+leela@hashrocket.com) This provides the ability to create a Gravatar for the pair.
-* Allows you to expire the pair information in N hours. e.g. hitch --expire 8 fry leela
+* Allows you to expire the pair information in N hours. (e.g. `hitch --expire 8 fry leela`)
+* Temporarily adds pair's ssh public keys to your `~/.ssh/authorized_keys`. (removes when you run `unhitch`)
 
 Synopsis:
 --------

--- a/lib/hitch/hitch.sh
+++ b/lib/hitch/hitch.sh
@@ -5,6 +5,7 @@
 hitch() {
   command hitch "$@"
   if [[ -s "$HOME/.hitch_export_authors" ]] ; then source "$HOME/.hitch_export_authors" ; fi
+  if [[ -s "$HOME/.hitch_ssh_keys" ]] ; then source "$HOME/.hitch_ssh_keys"; fi
 }
 alias unhitch='hitch -u'
 


### PR DESCRIPTION
When pairing, the ssh keys of all the pairs are added to `~/.ssh/authorized_keys` between the `#HITCH_START` and `#HITCH_END` delimiters. When `unhitch` is run, everything between those delimiters is deleted.
