### PR TITLE
Adds support for a localized hitch_pairs

### DIFF
--- a/lib/hitch/author.rb
+++ b/lib/hitch/author.rb
@@ -12,15 +12,21 @@ module Hitch
     end
 
     def self.write_file
-      File.open(hitch_pairs, File::CREAT|File::TRUNC|File::RDWR, 0644) do |out|
+      File.open(hitch_pairs_current_file, File::CREAT|File::TRUNC|File::RDWR, 0644) do |out|
         YAML.dump(available_pairs, out)
       end
     end
 
     private
 
+    def self.hitch_pairs_current_file
+      hitch_pairs.find { |file| File.exists?(file) }
+    end
+
     def self.hitch_pairs
-      File.expand_path("~/.hitch_pairs")
+      %w(./.hitch_pairs ~/.hitch_pairs).map { |file|
+        File.expand_path(file)
+      }
     end
 
     def self.available_pairs
@@ -28,11 +34,13 @@ module Hitch
     end
 
     def self.get_available_pairs
-      if File.exists?(hitch_pairs)
-        yamlized = YAML::load_file(hitch_pairs)
-        return yamlized if yamlized.kind_of?(Hash)
-      end
-      return {}
+      hitch_pairs.reduce({}) { |pairs, pair_file|
+        if File.exists?(pair_file)
+          yamlized = YAML::load_file(pair_file)
+          yamlized.merge!(pairs) if yamlized.kind_of?(Hash)
+        end
+        pairs
+      }
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,6 @@ RSpec.configure do |config|
   config.before(:each) do
     Hitch.stub(:hitchrc).and_return(Tempfile.new('hitchrc').path)
     Hitch.stub(:hitch_export_authors).and_return(Tempfile.new('hitch_export_authors').path)
-    Hitch::Author.stub(:hitch_pairs).and_return(Tempfile.new('hitch_pairs').path)
+    Hitch::Author.stub(:hitch_pairs).and_return([Tempfile.new('hitch_pairs')])
   end
 end


### PR DESCRIPTION
This is a proof of concept that would enable to have a .hitch_pairs localized in a project folder/repo in order to avoid polluting your general .hitch_pairs with one time only devs.

I haven't added tests because i'm still wondering what would be the best way to test this. I think maybe extracting those .hitch_pairs file concerns to its own file would make it easier to test.

I'm opening this PR for discussion. 