### PR TITLE
Add option to override group_email

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Synopsis:
 
 - For leela and fry to pair:
   - hitch leela fry
+- To override group email:
+  - hitch leela fry -g dev@hashrocket.com
 - To clear pair info:
   - hitch -u
 - For a complete list of features:

--- a/bin/hitch
+++ b/bin/hitch
@@ -17,6 +17,9 @@ opts = OptionParser.new do |opts|
   opts.on("-e N", "--expire N", Integer, "Expire pair information in N hours.") do |n|
     options = [:expire, n]
   end
+  opts.on("-g G", "--group G", "Set group email to G.") do |g|
+    options = [:group_email, g]
+  end
   opts.on("-u", "--unhitch", "Clear pair information") do
     options = [:unhitch]
   end
@@ -33,9 +36,15 @@ end
 
 if args.any?
   opts.parse!(args)
+
   if options.delete(:expire)
     system(Hitch.expire_command(options.pop))
   end
+
+  if options.delete(:group_email)
+    Hitch.group_email = options.pop
+  end
+
   options = [:export, args] if options.empty?
 else
   options = [:print_info]


### PR DESCRIPTION
### Description
When someone works on multiple projects at the same time, he/she has to
edit the hitch config file multiple times to change `group_email`.

This PR allows us to pass in `--group` or `-g` to quickly
set/override an existing `group_email`.

![Screen Shot 2020-03-29 at 12 22 17 PM](https://user-images.githubusercontent.com/2158281/77840266-f4e7b080-71b7-11ea-84a6-49a230315409.png)
